### PR TITLE
Automatically stub build in node modules when they are required. Fixes #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,32 @@ stubFactories.Meteor = function () {
 stubFactories.Npm = function () {
   return {
     depends: emptyFn,
-    require: emptyFn
+    require: function (module) {
+      var mockedModule = {}, nodeModule, key, originalProperty, originalPropertyType;
+
+      try {
+        nodeModule = require(module);
+      } catch(e) {
+        nodeModule = emptyFn;
+      }
+
+      for(key in nodeModule) {
+        originalProperty = nodeModule[key];
+        originalPropertyType = typeof originalProperty;
+
+        if (originalPropertyType === 'function') {
+          mockedModule[key] = emptyFn;
+        } else if (originalPropertyType === 'object') {
+          if (originalProperty instanceof Array) {
+            mockedModule[key] = [];
+          } else {
+            mockedModule[key] = {};
+          }
+        }
+      }
+
+      return mockedModule;
+    }
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "description": "Stubs for Meteor core objects",
   "homepage": "https://github.com/alanning/meteor-stubs",
   "version": "0.0.2",
-  "dependencies": {},
+  "dependencies": {
+    "fibers": "^1.0.1"
+  },
   "devDependencies": {},
   "maintainers": [
     {


### PR DESCRIPTION
As requested in my issue. 

I added fibers as a npm dependency because fibers will be a commonly used node module across all meteor applications.

This will not work for modules that are not packaged with node. We should think of a system where we can add extra modules to the meteor-stubs via some kind of setting. Although most people probaply use [the npm package](http://atmospherejs.com/package/npm) for other npm modules.
