### PR TITLE
Added "Meteor.call", "Meteor.apply", "Meteor.callInContext"

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,11 @@ stubFactories.Meteor = function () {
     publishFunctions: {},
     subscribeFunctions: {},
     methodMap: {},
-    Error: emptyFn,
+    Error: function(error, reason, details) {
+      if (error) this.error = error;
+      if (reason) this.reason = reason;
+      if (details) this.details = details;
+    },
     startup: function (newStartupFunction) {
       this.startupFunctions.push(newStartupFunction);
     },
@@ -215,21 +219,47 @@ stubFactories.Meteor = function () {
     valuesToArray: function (obj) {
       return Object.keys(obj).map(function (key) { return obj[key]; });
     },
+    executeFunction: function(func, args) {
+      var exception = null;
+      var result = null;
+
+      try {
+        result = func();
+      } catch (ex) {
+        exception = ex;
+      }
+
+      // if we specify the callback function execute it
+      if (args.length > 0 && typeof(args[args.length - 1]) === "function") {
+        args[args.length - 1](exception, result);
+      } else if (exception != null) {
+        // rethrow exception
+        throw exception;
+      }
+    },
     call: function(name, args) {
       var argumentArray = Meteor.valuesToArray(arguments);
       argumentArray.splice(0, 1);
-      Meteor.methodMap[name].apply(this, argumentArray);
+      Meteor.executeFunction(function() {
+        Meteor.methodMap[name].apply(this, argumentArray);
+      }, argumentArray);
     },
     callInContext: function(name, context, args) {
       var argumentArray = Meteor.valuesToArray(arguments);
       argumentArray.splice(0, 2);
-      Meteor.methodMap[name].apply(context, argumentArray);
+      Meteor.executeFunction(function() {
+        Meteor.methodMap[name].apply(context, argumentArray);
+      }, argumentArray);
     },
     apply: function(name, args) {
-      Meteor.methodMap[name].apply(this, args);
+      Meteor.executeFunction(function() {
+        Meteor.methodMap[name].apply(this, args);
+      }, args);
     },
     applyInContext: function(name, context, args) {
-      Meteor.methodMap[name].apply(context, args);
+      Meteor.executeFunction(function() {
+        Meteor.methodMap[name].apply(context, args);
+      }, args);
     },
     loggingIn: emptyFn,
     setInterval: emptyFn,


### PR DESCRIPTION
I would like to add the possibility to call the server methods in unit tests via `Meteor.call` and `Meteor.apply`, what is much less prone to API changes than calling directly in test Meteor.methodMap ....

I have also added two other methods which can set context for the server call `Meteor.callInContext` and `Meteor.applyInContext`
